### PR TITLE
Add support of cgroups

### DIFF
--- a/assets/run.common
+++ b/assets/run.common
@@ -7,6 +7,7 @@ do_mounts()
 
 	mount --bind /sys debian/sys/ > /dev/null
 	mount --bind /sys/fs/bpf/ debian/sys/fs/bpf/ > /dev/null
+	mount --bind /sys/fs/cgroup/ debian/sys/fs/cgroup/ > /dev/null
 	mount --bind /sys/kernel/debug/ debian/sys/kernel/debug/ > /dev/null
 
 	mount --bind /sys/kernel/tracing/ debian/sys/kernel/tracing/


### PR DESCRIPTION
In order to support cgroups, the directory from the Android OS should be mounted before running chroot command.